### PR TITLE
🐛 avert infinite loop when prod_id not assigned (#539)

### DIFF
--- a/BetterJoyForCemu/Program.cs
+++ b/BetterJoyForCemu/Program.cs
@@ -141,8 +141,11 @@ namespace BetterJoyForCemu {
                 }
 
                 ushort prod_id = thirdParty == null ? enumerate.product_id : TypeToProdId(thirdParty.type);
-                if (prod_id == 0)
-                    continue; // controller was not assigned a type
+                if (prod_id == 0) {
+                    ptr = enumerate.next; // controller was not assigned a type, but advance ptr anyway
+                    continue;
+                }
+
                 if (validController && !ControllerAlreadyAdded(enumerate.path)) {
                     switch (prod_id) {
                         case product_l:


### PR DESCRIPTION
Without ptr being reassigned in the case of a 0 prod_id, the app would get into an infinite loop on launch, before opening- this should resolve it 😊