### PR TITLE
🐛 fixes "too many items" when names are null

### DIFF
--- a/BetterJoyForCemu/3rdPartyControllers.cs
+++ b/BetterJoyForCemu/3rdPartyControllers.cs
@@ -40,7 +40,7 @@ namespace BetterJoyForCemu {
             }
 
             public override string ToString() {
-                return name;
+                return name ?? $"Unidentified Device ({this.product_id})";
             }
 
             public string Serialise() {


### PR DESCRIPTION
There is an (honestly misleading) OutOfMemoryException with the message "too many items in listbox" that is thrown when there are any items whose ToString() method returns null. This commit (in my maybe-biased opinion) gives a reasonable output in that case instead.